### PR TITLE
Bug/4 missing transforms

### DIFF
--- a/bipedal_bringup/launch/bipedal.launch.py
+++ b/bipedal_bringup/launch/bipedal.launch.py
@@ -72,7 +72,7 @@ def launch_setup(context, *args, **kwargs):
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_controllers],
+        parameters=[robot_description, robot_controllers],
         output="screen",
     )
 

--- a/bipedal_description/controllers/bipedal_controllers.yaml
+++ b/bipedal_description/controllers/bipedal_controllers.yaml
@@ -1,7 +1,6 @@
 controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
-    use_sim_time: true
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster


### PR DESCRIPTION
# WHY
When running ros2 launch bipedal_bringup bipedal.launch.py fake:=true rviz:=true the controller manager is not turned on, and RViz2 shows missing transformations.

# WHAT
- [Readded passing robot_description as parameter to control_node](https://github.com/energinet-digitalisering/reachy-bipedal/commit/866c456db794822d1907158ec9496c175ad72386)
- [use_sim_time should be false when not running Gazebo](https://github.com/energinet-digitalisering/reachy-bipedal/commit/75df29b2fb76c2f43b86610a6fe37287083b408b)

# RELATED
Closes https://github.com/energinet-digitalisering/reachy-bipedal/issues/4